### PR TITLE
59+63 flash interface setup

### DIFF
--- a/project/Core/Inc/flash_interface.h
+++ b/project/Core/Inc/flash_interface.h
@@ -10,6 +10,9 @@
 
 // Flash sector definitions
 #define FLASH_SECTOR_CAMERA     1
+#define FLASH_SECTOR_2          2  // Camera overflow
+#define FLASH_SECTOR_3          3  // Camera overflow
+#define FLASH_SECTOR_SENSORS    4
 #define FLASH_SECTOR_ALTIMETER  5
 #define FLASH_SECTOR_GPS        6
 #define FLASH_SECTOR_BATTERY    7
@@ -17,6 +20,9 @@
 // Flash sector addresses (based on STM32H7xx flash layout)
 // todo: NEED TO CONFIRM FROM DATASHEET
 #define FLASH_SECTOR_1_ADDRESS  0x08020000
+#define FLASH_SECTOR_2_ADDRESS  0x08040000
+#define FLASH_SECTOR_3_ADDRESS  0x08060000
+#define FLASH_SECTOR_4_ADDRESS  0x08080000
 #define FLASH_SECTOR_5_ADDRESS  0x080A0000
 #define FLASH_SECTOR_6_ADDRESS  0x080C0000
 #define FLASH_SECTOR_7_ADDRESS  0x080E0000

--- a/project/Core/Inc/flash_interface.h
+++ b/project/Core/Inc/flash_interface.h
@@ -9,38 +9,37 @@
 #include <stdio.h>
 
 // Flash sector definitions
-#define FLASH_SECTOR_CAMERA     1
-#define FLASH_SECTOR_2          2  // Camera overflow
-#define FLASH_SECTOR_3          3  // Camera overflow
-#define FLASH_SECTOR_SENSORS    4
-#define FLASH_SECTOR_ALTIMETER  5
-#define FLASH_SECTOR_GPS        6
-#define FLASH_SECTOR_BATTERY    7
+#define FLASH_SECTOR_CAMERA     1U
+#define FLASH_SECTOR_2          2U  // Camera overflow
+#define FLASH_SECTOR_3          3U  // Camera overflow
+#define FLASH_SECTOR_4          4U  // UNUSED
+#define FLASH_SECTOR_ALTIMETER  5U
+#define FLASH_SECTOR_GPS        6U
+#define FLASH_SECTOR_BATTERY    7U  // Shares sector 7 with sensor data
+#define FLASH_SECTOR_SENSORS    7U  // Consolidated into sector 7 with battery data
 
-// Flash sector addresses (based on STM32H7xx flash layout)
-// todo: NEED TO CONFIRM FROM DATASHEET
-#define FLASH_SECTOR_1_ADDRESS  0x08020000
-#define FLASH_SECTOR_2_ADDRESS  0x08040000
-#define FLASH_SECTOR_3_ADDRESS  0x08060000
-#define FLASH_SECTOR_4_ADDRESS  0x08080000
-#define FLASH_SECTOR_5_ADDRESS  0x080A0000
-#define FLASH_SECTOR_6_ADDRESS  0x080C0000
-#define FLASH_SECTOR_7_ADDRESS  0x080E0000
+// Note: Flash sector size and base addresses are provided by STM32 HAL
+// FLASH_SECTOR_SIZE (128KB) and FLASH_BANK1_BASE are defined in stm32h743xx.h
 
-// Flash sector size (128KB for STM32H7xx)
-#define FLASH_SECTOR_SIZE       0x20000
+// Sector 7 memory layout offsets - Both battery and sensor data are stored in sector 7
+// Layout: [Battery Data + Magic][Padding][Sensor Data + Magic][Remaining Space]
+#define BATTERY_DATA_OFFSET     0U      // Battery data starts at sector beginning
+#define SENSOR_DATA_OFFSET      64U     // Sensor data starts after battery data + padding
 
 /*
 flash_write: 
     writes a section of memory into a specified location in flash memory, returns success or failure
+    NOTE: Sector must be cleared (erased) before writing. Call flash_clear first or ensure 
+    the calling code handles sector clearing before writing.
 Parameters:
     memory_address: a pointer to the start address of the source data in memory
     memory_size: the amount of memory to copy to flash
-    flash_sector_flag: the flash sector number (1, 5, 6, or 7)
+    flash_sector_flag: the flash sector number (1, 2, 3, 4, 5, 6, or 7)
+    offset_address: OPTIONAL offset within the sector (0 = sector start, non-zero = specific offset)
 Return:
     returns a true boolean for success and a false boolean for failure 
 */
-bool flash_write(void* memory_address, int memory_size, uint8_t flash_sector_flag);
+bool flash_write(void* memory_address, int memory_size, uint8_t flash_sector_flag, uint32_t offset_address);
 
 /*
 flash_read:
@@ -48,17 +47,19 @@ flash_read:
 Parameters:
     memory_address: a pointer to the start address of the destination in memory
     memory_size: the amount of memory to copy from flash
-    flash_sector_flag: the flash sector number (1, 5, 6, or 7)
+    flash_sector_flag: the flash sector number (1, 2, 3, 4, 5, 6, or 7)
+    offset_address: OPTIONAL offset within the sector (0 = sector start, non-zero = specific offset)
 Return:
     returns a true boolean for success and a false boolean for failure   
 */
-bool flash_read(void* memory_address, int memory_size, uint8_t flash_sector_flag);
+bool flash_read(void* memory_address, int memory_size, uint8_t flash_sector_flag, uint32_t offset_address);
 
 /*
 flash_clear:
     erases the entire flash sector, setting all bits to 1 (0xFF)
+    Must be called before flash_write to prepare the sector for new data.
 Parameters:
-    flash_sector_flag: the flash sector number (1, 5, 6, or 7)
+    flash_sector_flag: the flash sector number (1, 2, 3, 4, 5, 6, or 7)
 Return:
     returns a true boolean for success and a false boolean for failure   
 */

--- a/project/Core/Inc/flash_interface.h
+++ b/project/Core/Inc/flash_interface.h
@@ -15,6 +15,7 @@
 #define FLASH_SECTOR_BATTERY    7
 
 // Flash sector addresses (based on STM32H7xx flash layout)
+// todo: NEED TO CONFIRM FROM DATASHEET
 #define FLASH_SECTOR_1_ADDRESS  0x08020000
 #define FLASH_SECTOR_5_ADDRESS  0x080A0000
 #define FLASH_SECTOR_6_ADDRESS  0x080C0000

--- a/project/Core/Inc/flash_interface.h
+++ b/project/Core/Inc/flash_interface.h
@@ -8,17 +8,32 @@
 #include <string.h>
 #include <stdio.h>
 
+// Flash sector definitions
+#define FLASH_SECTOR_CAMERA     1
+#define FLASH_SECTOR_ALTIMETER  5
+#define FLASH_SECTOR_GPS        6
+#define FLASH_SECTOR_BATTERY    7
+
+// Flash sector addresses (based on STM32H7xx flash layout)
+#define FLASH_SECTOR_1_ADDRESS  0x08020000
+#define FLASH_SECTOR_5_ADDRESS  0x080A0000
+#define FLASH_SECTOR_6_ADDRESS  0x080C0000
+#define FLASH_SECTOR_7_ADDRESS  0x080E0000
+
+// Flash sector size (128KB for STM32H7xx)
+#define FLASH_SECTOR_SIZE       0x20000
+
 /*
 flash_write: 
     writes a section of memory into a specified location in flash memory, returns success or failure
 Parameters:
     memory_address: a pointer to the start address of the source data in memory
     memory_size: the amount of memory to copy to flash
-    flash_address: the destination address in flash memory
+    flash_sector_flag: the flash sector number (1, 5, 6, or 7)
 Return:
     returns a true boolean for success and a false boolean for failure 
 */
-bool flash_write(void* memory_address, int memory_size, uint16_t flash_address);
+bool flash_write(void* memory_address, int memory_size, uint8_t flash_sector_flag);
 
 /*
 flash_read:
@@ -26,8 +41,18 @@ flash_read:
 Parameters:
     memory_address: a pointer to the start address of the destination in memory
     memory_size: the amount of memory to copy from flash
-    flash_address: the source address in flash memory
+    flash_sector_flag: the flash sector number (1, 5, 6, or 7)
 Return:
     returns a true boolean for success and a false boolean for failure   
 */
-bool flash_read(void* memory_address, int memory_size, uint16_t flash_address);
+bool flash_read(void* memory_address, int memory_size, uint8_t flash_sector_flag);
+
+/*
+flash_clear:
+    erases the entire flash sector, setting all bits to 1 (0xFF)
+Parameters:
+    flash_sector_flag: the flash sector number (1, 5, 6, or 7)
+Return:
+    returns a true boolean for success and a false boolean for failure   
+*/
+bool flash_clear(uint8_t flash_sector_flag);

--- a/project/Core/Src/camera.c
+++ b/project/Core/Src/camera.c
@@ -30,6 +30,7 @@
 #include "camera.h"
 #include "camera_recovery.h"
 #include "camera_bsp.h"
+#include "flash_interface.h"
 
 /** @def SWITCH_CAMERA(camera, state)
  *  @brief Macro to switch camera state via GPIO
@@ -297,39 +298,19 @@ int32_t camera_init(Camera_t *camera) {
  * @note Frees the image buffer after saving
  */
 void save_image_to_flash(Camera_t *camera, uint32_t sector) {
-    if (camera->imageBuffer == NULL){
-        // Handle error if image buffer is empty
+    if (camera->imageBuffer == NULL) {
         return;
     }
 
-    uint32_t sectorError;
-
-    // unlock flash memory
-    HAL_FLASH_Unlock();
-
-    HAL_FLASHEx_Erase(&(FLASH_EraseInitTypeDef){
-        .TypeErase = FLASH_TYPEERASE_SECTORS,
-        .Sector = sector,  // Sector to erase (e.g., FLASH_SECTOR_2 or FLASH_SECTOR_3)
-        .NbSectors = 1,
-        .VoltageRange = FLASH_VOLTAGE_RANGE_3
-    }, &sectorError);
-
-    if (sectorError != 0xFFFFFFFF) {
-        // Handle error
-        HAL_FLASH_Lock();
-        return;
+    uint8_t flash_sector_flag = FLASH_SECTOR_CAMERA;
+    if (sector == FLASH_SECTOR_2) {
+        flash_sector_flag = FLASH_SECTOR_CAMERA;
+    } else if (sector == FLASH_SECTOR_3) {
+        flash_sector_flag = FLASH_SECTOR_CAMERA;
     }
 
-    uint32_t flashAddress = FLASH_BASE + (sector * FLASH_SECTOR_SIZE);
-    for (uint32_t i = 0; i < camera->imageSize / 4; i++) {
-        HAL_FLASH_Program(FLASH_TYPEPROGRAM_FLASHWORD, flashAddress + (i * 4),
-                          ((uint32_t *)camera->imageBuffer)[i]);
-    }
+    flash_write(camera->imageBuffer, camera->actualImageSize, flash_sector_flag);
 
-    // lock flash memory
-    HAL_FLASH_Lock();
-
-    // empty image buffer to save RAM
     free(camera->imageBuffer);
     camera->imageBuffer = NULL;
 }

--- a/project/Core/Src/camera.c
+++ b/project/Core/Src/camera.c
@@ -302,14 +302,25 @@ void save_image_to_flash(Camera_t *camera, uint32_t sector) {
         return;
     }
 
-    uint8_t flash_sector_flag = FLASH_SECTOR_CAMERA;
+    // Check if image size exceeds flash sector size
+    if (camera->actualImageSize > FLASH_SECTOR_SIZE) {
+        // TODO: Handle oversized image - split across multiple sectors
+        return;
+    }
+    
+    // Use the sector parameter to determine storage location
+    uint8_t flash_sector_flag;
     if (sector == FLASH_SECTOR_2) {
-        flash_sector_flag = FLASH_SECTOR_CAMERA;
+        flash_sector_flag = FLASH_SECTOR_2;
     } else if (sector == FLASH_SECTOR_3) {
-        flash_sector_flag = FLASH_SECTOR_CAMERA;
+        flash_sector_flag = FLASH_SECTOR_3;
+    } else {
+        flash_sector_flag = FLASH_SECTOR_CAMERA; // Default to sector 1
     }
 
-    flash_write(camera->imageBuffer, camera->actualImageSize, flash_sector_flag);
+    if (!flash_write(camera->imageBuffer, camera->actualImageSize, flash_sector_flag)) {
+        // TODO: Handle flash write error
+    }
 
     free(camera->imageBuffer);
     camera->imageBuffer = NULL;

--- a/project/Core/Src/camera.c
+++ b/project/Core/Src/camera.c
@@ -318,7 +318,7 @@ void save_image_to_flash(Camera_t *camera, uint32_t sector) {
         flash_sector_flag = FLASH_SECTOR_CAMERA; // Default to sector 1
     }
 
-    if (!flash_write(camera->imageBuffer, camera->actualImageSize, flash_sector_flag)) {
+    if (!flash_write(camera->imageBuffer, camera->actualImageSize, flash_sector_flag, 0)) {
         // TODO: Handle flash write error
     }
 

--- a/project/Core/Src/flash_interface.c
+++ b/project/Core/Src/flash_interface.c
@@ -5,6 +5,121 @@ this will contain flash storage and retrieval functions
 functions are documented in flash_interface.h
 */
 
-bool flash_write(void* memory_address, int memory_size, uint16_t flash_address);
+static uint32_t get_sector_address(uint8_t flash_sector_flag) {
+    switch (flash_sector_flag) {
+        case FLASH_SECTOR_CAMERA:
+            return FLASH_SECTOR_1_ADDRESS;
+        case FLASH_SECTOR_ALTIMETER:
+            return FLASH_SECTOR_5_ADDRESS;
+        case FLASH_SECTOR_GPS:
+            return FLASH_SECTOR_6_ADDRESS;
+        case FLASH_SECTOR_BATTERY:
+            return FLASH_SECTOR_7_ADDRESS;
+        default:
+            return 0;
+    }
+}
 
-bool flash_read(void* memory_address, int memory_size, uint16_t flash_address);
+static uint32_t get_hal_sector(uint8_t flash_sector_flag) {
+    switch (flash_sector_flag) {
+        case FLASH_SECTOR_CAMERA:
+            return FLASH_SECTOR_1;
+        case FLASH_SECTOR_ALTIMETER:
+            return FLASH_SECTOR_5;
+        case FLASH_SECTOR_GPS:
+            return FLASH_SECTOR_6;
+        case FLASH_SECTOR_BATTERY:
+            return FLASH_SECTOR_7;
+        default:
+            return 0xFFFFFFFF;
+    }
+}
+
+bool flash_read(void* memory_address, int memory_size, uint8_t flash_sector_flag) {
+    if (memory_address == NULL || memory_size <= 0) {
+        return false;
+    }
+    
+    uint32_t sector_address = get_sector_address(flash_sector_flag);
+    if (sector_address == 0) {
+        return false;
+    }
+    
+    uint32_t *flash_data = (uint32_t *)sector_address;
+    uint32_t *dest = (uint32_t *)memory_address;
+    
+    if (flash_data[0] == 0xDEADBEEF) {
+        memcpy(dest, flash_data, memory_size);
+        return true;
+    } else {
+        memset(dest, 0, memory_size);
+        return false;
+    }
+}
+
+bool flash_write(void* memory_address, int memory_size, uint8_t flash_sector_flag) {
+    if (memory_address == NULL || memory_size <= 0) {
+        return false;
+    }
+    
+    uint32_t sector_address = get_sector_address(flash_sector_flag);
+    uint32_t hal_sector = get_hal_sector(flash_sector_flag);
+    
+    if (sector_address == 0 || hal_sector == 0xFFFFFFFF) {
+        return false;
+    }
+    
+    HAL_FLASH_Unlock();
+    
+    FLASH_EraseInitTypeDef erase;
+    uint32_t pageError;
+    
+    erase.TypeErase = FLASH_TYPEERASE_SECTORS;
+    erase.Sector = hal_sector;
+    erase.NbSectors = 1;
+    erase.VoltageRange = FLASH_VOLTAGE_RANGE_3;
+    
+    if (HAL_FLASHEx_Erase(&erase, &pageError) != HAL_OK) {
+        HAL_FLASH_Lock();
+        return false;
+    }
+    
+    uint64_t *src = (uint64_t *)memory_address;
+    uint32_t numWords = (memory_size + 7) / 8;
+    
+    for (uint32_t i = 0; i < numWords; i++) {
+        if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_FLASHWORD, sector_address + (i * 8), src[i]) != HAL_OK) {
+            HAL_FLASH_Lock();
+            return false;
+        }
+    }
+    
+    HAL_FLASH_Lock();
+    return true;
+}
+
+bool flash_clear(uint8_t flash_sector_flag) {
+    uint32_t hal_sector = get_hal_sector(flash_sector_flag);
+    
+    if (hal_sector == 0xFFFFFFFF) {
+        return false;
+    }
+    
+    HAL_FLASH_Unlock();
+    
+    FLASH_EraseInitTypeDef erase;
+    uint32_t pageError;
+    
+    erase.TypeErase = FLASH_TYPEERASE_SECTORS;
+    erase.Sector = hal_sector;
+    erase.NbSectors = 1;
+    erase.VoltageRange = FLASH_VOLTAGE_RANGE_3;
+    
+    if (HAL_FLASHEx_Erase(&erase, &pageError) != HAL_OK) {
+        HAL_FLASH_Lock();
+        return false;
+    }
+    
+    HAL_FLASH_Lock();
+    return true;
+}

--- a/project/Core/Src/flash_interface.c
+++ b/project/Core/Src/flash_interface.c
@@ -6,48 +6,18 @@ functions are documented in flash_interface.h
 */
 
 static uint32_t get_sector_address(uint8_t flash_sector_flag) {
-    switch (flash_sector_flag) {
-        case FLASH_SECTOR_CAMERA:
-            return FLASH_SECTOR_1_ADDRESS;
-        case FLASH_SECTOR_2:
-            return FLASH_SECTOR_2_ADDRESS;
-        case FLASH_SECTOR_3:
-            return FLASH_SECTOR_3_ADDRESS;
-        case FLASH_SECTOR_SENSORS:
-            return FLASH_SECTOR_4_ADDRESS;
-        case FLASH_SECTOR_ALTIMETER:
-            return FLASH_SECTOR_5_ADDRESS;
-        case FLASH_SECTOR_GPS:
-            return FLASH_SECTOR_6_ADDRESS;
-        case FLASH_SECTOR_BATTERY:
-            return FLASH_SECTOR_7_ADDRESS;
-        default:
-            return 0;
+    // Validate sector range (sectors 1-7 are used, sector 0 is reserved)
+    if (flash_sector_flag < 1U || flash_sector_flag > 7U) {
+        return 0;
     }
+    
+    // Calculate address using HAL constants: FLASH_BANK1_BASE + (sector * FLASH_SECTOR_SIZE)
+    // This gives us the correct offset addressing that starts from sector 1
+    return FLASH_BANK1_BASE + (flash_sector_flag * FLASH_SECTOR_SIZE);
 }
 
-static uint32_t get_hal_sector(uint8_t flash_sector_flag) {
-    switch (flash_sector_flag) {
-        case FLASH_SECTOR_CAMERA:
-            return FLASH_SECTOR_1;
-        case FLASH_SECTOR_2:
-            return FLASH_SECTOR_2;
-        case FLASH_SECTOR_3:
-            return FLASH_SECTOR_3;
-        case FLASH_SECTOR_SENSORS:
-            return FLASH_SECTOR_4;
-        case FLASH_SECTOR_ALTIMETER:
-            return FLASH_SECTOR_5;
-        case FLASH_SECTOR_GPS:
-            return FLASH_SECTOR_6;
-        case FLASH_SECTOR_BATTERY:
-            return FLASH_SECTOR_7;
-        default:
-            return 0xFFFFFFFF;
-    }
-}
 
-bool flash_read(void* memory_address, int memory_size, uint8_t flash_sector_flag) {
+bool flash_read(void* memory_address, int memory_size, uint8_t flash_sector_flag, uint32_t offset_address) {
     if (memory_address == NULL || memory_size <= 0) {
         return false;
     }
@@ -57,7 +27,14 @@ bool flash_read(void* memory_address, int memory_size, uint8_t flash_sector_flag
         return false;
     }
     
-    uint8_t *flash_data = (uint8_t *)sector_address;
+    uint32_t read_address = sector_address + offset_address;
+    
+    // Validate that read doesn't exceed sector boundary
+    if (offset_address + memory_size + 4 > FLASH_SECTOR_SIZE) {
+        return false;
+    }
+    
+    uint8_t *flash_data = (uint8_t *)read_address;
     uint8_t *dest = (uint8_t *)memory_address;
     
     if (*(uint32_t*)flash_data == 0xDEADBEEF) {
@@ -69,35 +46,28 @@ bool flash_read(void* memory_address, int memory_size, uint8_t flash_sector_flag
     }
 }
 
-bool flash_write(void* memory_address, int memory_size, uint8_t flash_sector_flag) {
+bool flash_write(void* memory_address, int memory_size, uint8_t flash_sector_flag, uint32_t offset_address) {
     if (memory_address == NULL || memory_size <= 0) {
         return false;
     }
     
     uint32_t sector_address = get_sector_address(flash_sector_flag);
-    uint32_t hal_sector = get_hal_sector(flash_sector_flag);
     
-    if (sector_address == 0 || hal_sector == 0xFFFFFFFF) {
+    if (sector_address == 0) {
+        return false;
+    }
+    
+    uint32_t write_address = sector_address + offset_address;
+    
+    // Validate that write doesn't exceed sector boundary
+    if (offset_address + memory_size + 4 > FLASH_SECTOR_SIZE) {
         return false;
     }
     
     HAL_FLASH_Unlock();
     
-    FLASH_EraseInitTypeDef erase;
-    uint32_t pageError;
-    
-    erase.TypeErase = FLASH_TYPEERASE_SECTORS;
-    erase.Sector = hal_sector;
-    erase.NbSectors = 1;
-    erase.VoltageRange = FLASH_VOLTAGE_RANGE_3;
-    
-    if (HAL_FLASHEx_Erase(&erase, &pageError) != HAL_OK) {
-        HAL_FLASH_Lock();
-        return false;
-    }
-    
     // Write magic number first
-    if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_WORD, sector_address, 0xDEADBEEF) != HAL_OK) {
+    if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_WORD, write_address, 0xDEADBEEF) != HAL_OK) {
         HAL_FLASH_Lock();
         return false;
     }
@@ -106,7 +76,7 @@ bool flash_write(void* memory_address, int memory_size, uint8_t flash_sector_fla
     uint32_t numWords = (memory_size + 7) / 8;
     
     for (uint32_t i = 0; i < numWords; i++) {
-        if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, sector_address + 4 + (i * 8), src[i]) != HAL_OK) {
+        if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, write_address + 4 + (i * 8), src[i]) != HAL_OK) {
             HAL_FLASH_Lock();
             return false;
         }
@@ -117,9 +87,7 @@ bool flash_write(void* memory_address, int memory_size, uint8_t flash_sector_fla
 }
 
 bool flash_clear(uint8_t flash_sector_flag) {
-    uint32_t hal_sector = get_hal_sector(flash_sector_flag);
-    
-    if (hal_sector == 0xFFFFFFFF) {
+    if (flash_sector_flag < FLASH_SECTOR_CAMERA || flash_sector_flag > FLASH_SECTOR_BATTERY) {
         return false;
     }
     
@@ -129,7 +97,7 @@ bool flash_clear(uint8_t flash_sector_flag) {
     uint32_t pageError;
     
     erase.TypeErase = FLASH_TYPEERASE_SECTORS;
-    erase.Sector = hal_sector;
+    erase.Sector = flash_sector_flag;
     erase.NbSectors = 1;
     erase.VoltageRange = FLASH_VOLTAGE_RANGE_3;
     

--- a/project/Core/Src/flash_interface.c
+++ b/project/Core/Src/flash_interface.c
@@ -9,6 +9,12 @@ static uint32_t get_sector_address(uint8_t flash_sector_flag) {
     switch (flash_sector_flag) {
         case FLASH_SECTOR_CAMERA:
             return FLASH_SECTOR_1_ADDRESS;
+        case FLASH_SECTOR_2:
+            return FLASH_SECTOR_2_ADDRESS;
+        case FLASH_SECTOR_3:
+            return FLASH_SECTOR_3_ADDRESS;
+        case FLASH_SECTOR_SENSORS:
+            return FLASH_SECTOR_4_ADDRESS;
         case FLASH_SECTOR_ALTIMETER:
             return FLASH_SECTOR_5_ADDRESS;
         case FLASH_SECTOR_GPS:
@@ -24,6 +30,12 @@ static uint32_t get_hal_sector(uint8_t flash_sector_flag) {
     switch (flash_sector_flag) {
         case FLASH_SECTOR_CAMERA:
             return FLASH_SECTOR_1;
+        case FLASH_SECTOR_2:
+            return FLASH_SECTOR_2;
+        case FLASH_SECTOR_3:
+            return FLASH_SECTOR_3;
+        case FLASH_SECTOR_SENSORS:
+            return FLASH_SECTOR_4;
         case FLASH_SECTOR_ALTIMETER:
             return FLASH_SECTOR_5;
         case FLASH_SECTOR_GPS:
@@ -45,11 +57,11 @@ bool flash_read(void* memory_address, int memory_size, uint8_t flash_sector_flag
         return false;
     }
     
-    uint32_t *flash_data = (uint32_t *)sector_address;
-    uint32_t *dest = (uint32_t *)memory_address;
+    uint8_t *flash_data = (uint8_t *)sector_address;
+    uint8_t *dest = (uint8_t *)memory_address;
     
-    if (flash_data[0] == 0xDEADBEEF) {
-        memcpy(dest, flash_data, memory_size);
+    if (*(uint32_t*)flash_data == 0xDEADBEEF) {
+        memcpy(dest, flash_data + 4, memory_size);
         return true;
     } else {
         memset(dest, 0, memory_size);
@@ -84,11 +96,17 @@ bool flash_write(void* memory_address, int memory_size, uint8_t flash_sector_fla
         return false;
     }
     
+    // Write magic number first
+    if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_WORD, sector_address, 0xDEADBEEF) != HAL_OK) {
+        HAL_FLASH_Lock();
+        return false;
+    }
+    
     uint64_t *src = (uint64_t *)memory_address;
     uint32_t numWords = (memory_size + 7) / 8;
     
     for (uint32_t i = 0; i < numWords; i++) {
-        if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_FLASHWORD, sector_address + (i * 8), src[i]) != HAL_OK) {
+        if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, sector_address + 4 + (i * 8), src[i]) != HAL_OK) {
             HAL_FLASH_Lock();
             return false;
         }

--- a/project/Core/Src/obc.c
+++ b/project/Core/Src/obc.c
@@ -3,6 +3,7 @@
 #include "camera.h"
 #include "main.h"
 #include "time.h"
+#include "flash_interface.h"
 
 int mode = NOMINAL_MODE; // Start the payload in nominal mode
 HAL_StatusTypeDef status;
@@ -43,7 +44,7 @@ void obc_notifications(void *vpParameters) {
         			camera = 1;
         			status = capture_snapshot(camera1);
         			if (status == HAL_OK) {
-        				save_image_to_flash(camera1, camera_sector); // TODO: Set camera sector
+        				save_image_to_flash(camera1, FLASH_SECTOR_CAMERA);
         				store_image(camera1->imageBuffer);
         			} else {
         				xTaskNotify(ttc_notifications, ERROR & CAMERA & SUB_1, eSetValueWithOverwrite);
@@ -54,7 +55,7 @@ void obc_notifications(void *vpParameters) {
         			camera = 2;
         			status = capture_snapshot(camera2);
         			if (status == HAL_OK) {
-        			    save_image_to_flash(camera2, camera_sector); // TODO: Set camera sector
+        			    save_image_to_flash(camera2, FLASH_SECTOR_CAMERA);
         			    store_image(camera2->imageBuffer);
         			} else {
         				xTaskNotify(ttc_notifications, ERROR & CAMERA & SUB_2, eSetValueWithOverwrite);
@@ -139,7 +140,7 @@ void image_task(void *vpParameters) {
 		camera = 1;
 		status = capture_snapshot(camera1);
 		if (status == HAL_OK) {
-			save_image_to_flash(camera1, camera_sector); // TODO: Set camera sector
+			save_image_to_flash(camera1, FLASH_SECTOR_CAMERA);
 			store_image(camera1->imageBuffer);
 		} else {
 			xTaskNotify(ttc_notifications, ERROR & CAMERA & SUB_1, eSetValueWithOverwrite);
@@ -156,7 +157,7 @@ void image_task(void *vpParameters) {
 		camera = 2;
 		status = capture_snapshot(camera2);
 		if (status == HAL_OK) {
-			save_image_to_flash(camera2, camera_sector); // TODO: Set camera sector
+			save_image_to_flash(camera2, FLASH_SECTOR_CAMERA);
 			store_image(camera2->imageBuffer);
 		} else {
 			xTaskNotify(ttc_notifications, ERROR & CAMERA & SUB_2, eSetValueWithOverwrite);

--- a/project/Core/Src/obc_interface.c
+++ b/project/Core/Src/obc_interface.c
@@ -108,7 +108,9 @@ BatteryData get_battery_data(float dt) {
 }
 
 void save_battery_data_to_flash(BatteryData *data) {
-    flash_write(data, sizeof(BatteryData), FLASH_SECTOR_BATTERY);
+    if (!flash_write(data, sizeof(BatteryData), FLASH_SECTOR_BATTERY)) {
+        // TODO: Handle flash write error
+    }
 }
 
 void load_battery_data_from_flash() {
@@ -125,11 +127,13 @@ void init_sensors() {
 }
 
 void save_sensor_data_to_flash(SensorsData *data) {
-    flash_write(data, sizeof(SensorsData), FLASH_SECTOR_BATTERY);
+    if (!flash_write(data, sizeof(SensorsData), FLASH_SECTOR_SENSORS)) {
+        // TODO: Handle flash write error
+    }
 }
 
 void load_sensor_data_from_flash() {
-    if (!flash_read(&sensor_backup, sizeof(SensorsData), FLASH_SECTOR_BATTERY)) {
+    if (!flash_read(&sensor_backup, sizeof(SensorsData), FLASH_SECTOR_SENSORS)) {
         memset(&sensor_backup, 0, sizeof(SensorsData));
     }
 }

--- a/project/Core/Src/obc_interface.c
+++ b/project/Core/Src/obc_interface.c
@@ -1,6 +1,7 @@
 #include "obc_interface.h"
 #include "camera.h"
 #include "main.h"
+#include "flash_interface.h"
 
 // TODO: Move flash addresses to main.h and include each used address
 
@@ -107,43 +108,11 @@ BatteryData get_battery_data(float dt) {
 }
 
 void save_battery_data_to_flash(BatteryData *data) {
-	HAL_FLASH_Unlock();
-
-	    // 1. Setup flash erase configuration
-	    FLASH_EraseInitTypeDef erase;
-	    uint32_t pageError;
-
-	    erase.TypeErase = FLASH_TYPEERASE_SECTORS;       // Erase by sector
-	    erase.Sector = FLASH_SECTOR_7;                   // Make sure this is correct for your chip!
-	    erase.NbSectors = 1;
-	    erase.VoltageRange = FLASH_VOLTAGE_RANGE_3;      // 2.7V to 3.6V
-
-	    if (HAL_FLASHEx_Erase(&erase, &pageError) != HAL_OK) {
-	        // Handle erase error
-	        HAL_FLASH_Lock();
-	        return;
-	    }
-
-	    // 2. Write the data in 64-bit chunks
-	    uint64_t *src = (uint64_t *)data;
-	    uint32_t numWords = sizeof(BatteryData) / 8;
-
-	    for (uint32_t i = 0; i < numWords; i++) {
-	        if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_FLASHWORD, FLASH_SAVE_ADDRESS + (i * 8), src[i]) != HAL_OK) {
-	            // Handle write error
-	            HAL_FLASH_Lock();
-	            return;
-	        }
-	    }
-
-	    HAL_FLASH_Lock();
+    flash_write(data, sizeof(BatteryData), FLASH_SECTOR_BATTERY);
 }
 
 void load_battery_data_from_flash() {
-    BatteryData *flash_data = (BatteryData *)FLASH_SAVE_ADDRESS;
-    if (flash_data->magic == FLASH_MAGIC) {
-        memcpy(&battery_backup, flash_data, sizeof(BatteryData));
-    } else {
+    if (!flash_read(&battery_backup, sizeof(BatteryData), FLASH_SECTOR_BATTERY)) {
         memset(&battery_backup, 0, sizeof(BatteryData));
     }
 }
@@ -155,44 +124,12 @@ void init_sensors() {
     HAL_ADC_Start(&PressureSensor);
 }
 
-void save_sensor_data_to_flash(SensorsData *data){ // write to flash wrapper
-    HAL_FLASH_Unlock();
-
-    // 1. Setup flash erase configuration
-    FLASH_EraseInitTypeDef erase;
-    uint32_t pageError;
-
-    erase.TypeErase = FLASH_TYPEERASE_SECTORS;       // Erase by sector
-    erase.Sector = FLASH_SENSOR_ADDRESS;                   // Make sure this is correct for your chip!
-    erase.NbSectors = 1;
-    erase.VoltageRange = FLASH_VOLTAGE_RANGE_3;      // 2.7V to 3.6V
-
-    if (HAL_FLASHEx_Erase(&erase, &pageError) != HAL_OK) {
-        // Handle erase error
-        HAL_FLASH_Lock();
-        return;
-    }
-
-    // 2. Write the data in 64-bit chunks
-    uint64_t *src = (uint64_t *)data;
-    uint32_t numWords = sizeof(SensorsData) / 8;
-
-    for (uint32_t i = 0; i < numWords; i++) {
-        if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_FLASHWORD, FLASH_SENSOR_ADDRESS + (i * 8), src[i]) != HAL_OK) {
-            // Handle write error
-            HAL_FLASH_Lock();
-            return;
-        }
-    }
-
-    HAL_FLASH_Lock();
+void save_sensor_data_to_flash(SensorsData *data) {
+    flash_write(data, sizeof(SensorsData), FLASH_SECTOR_BATTERY);
 }
 
-void load_sensor_data_from_flash(){ // retrieves flash data and uses a pointer to write it to the sensor_backup struct
-    SensorsData *flash_data = (SensorsData *)FLASH_SENSOR_ADDRESS;
-    if (flash_data->magic == FLASH_MAGIC) {
-        memcpy(&sensor_backup, flash_data, sizeof(SensorsData));
-    } else {
+void load_sensor_data_from_flash() {
+    if (!flash_read(&sensor_backup, sizeof(SensorsData), FLASH_SECTOR_BATTERY)) {
         memset(&sensor_backup, 0, sizeof(SensorsData));
     }
 }

--- a/project/Core/Src/obc_interface.c
+++ b/project/Core/Src/obc_interface.c
@@ -108,13 +108,13 @@ BatteryData get_battery_data(float dt) {
 }
 
 void save_battery_data_to_flash(BatteryData *data) {
-    if (!flash_write(data, sizeof(BatteryData), FLASH_SECTOR_BATTERY)) {
+    if (!flash_write(data, sizeof(BatteryData), FLASH_SECTOR_BATTERY, BATTERY_DATA_OFFSET)) {
         // TODO: Handle flash write error
     }
 }
 
 void load_battery_data_from_flash() {
-    if (!flash_read(&battery_backup, sizeof(BatteryData), FLASH_SECTOR_BATTERY)) {
+    if (!flash_read(&battery_backup, sizeof(BatteryData), FLASH_SECTOR_BATTERY, BATTERY_DATA_OFFSET)) {
         memset(&battery_backup, 0, sizeof(BatteryData));
     }
 }
@@ -127,13 +127,13 @@ void init_sensors() {
 }
 
 void save_sensor_data_to_flash(SensorsData *data) {
-    if (!flash_write(data, sizeof(SensorsData), FLASH_SECTOR_SENSORS)) {
+    if (!flash_write(data, sizeof(SensorsData), FLASH_SECTOR_SENSORS, SENSOR_DATA_OFFSET)) {
         // TODO: Handle flash write error
     }
 }
 
 void load_sensor_data_from_flash() {
-    if (!flash_read(&sensor_backup, sizeof(SensorsData), FLASH_SECTOR_SENSORS)) {
+    if (!flash_read(&sensor_backup, sizeof(SensorsData), FLASH_SECTOR_SENSORS, SENSOR_DATA_OFFSET)) {
         memset(&sensor_backup, 0, sizeof(SensorsData));
     }
 }

--- a/project/Core/Src/ttc_interface.c
+++ b/project/Core/Src/ttc_interface.c
@@ -23,7 +23,7 @@ Returns:
 */
 bool get_gps(){ // this is formatted for polling
     HAL_UART_Receive (&huart3, gps_rx_buffer, NMEA_sentence_size, interrupt_timeout_length);
-    if(flash_write(*gps_rx_buffer, NMEA_sentence_size, GPS_FLASH_ADDRESS) == true){
+    if(flash_write(gps_rx_buffer, NMEA_sentence_size, FLASH_SECTOR_GPS) == true){
         return true;
     }
     return false;

--- a/project/Core/Src/ttc_interface.c
+++ b/project/Core/Src/ttc_interface.c
@@ -23,7 +23,7 @@ Returns:
 */
 bool get_gps(){ // this is formatted for polling
     HAL_UART_Receive (&huart3, gps_rx_buffer, NMEA_sentence_size, interrupt_timeout_length);
-    if(flash_write(gps_rx_buffer, NMEA_sentence_size, FLASH_SECTOR_GPS) == true){
+    if(flash_write(gps_rx_buffer, NMEA_sentence_size, FLASH_SECTOR_GPS, 0) == true){
         return true;
     }
     return false;

--- a/project/Core/Src/ttc_interface.c
+++ b/project/Core/Src/ttc_interface.c
@@ -22,7 +22,7 @@ Returns:
 
 */
 bool get_gps(){ // this is formatted for polling
-    HAL_UART_Receive (&huart3, gps_rx_buffer, NMEA_sentence_size, interrupt_timeout_length);
+    HAL_UART_Receive (&huart4, gps_rx_buffer, NMEA_sentence_size, interrupt_timeout_length);
     if(flash_write(gps_rx_buffer, NMEA_sentence_size, FLASH_SECTOR_GPS, 0) == true){
         return true;
     }


### PR DESCRIPTION
All sensors now use the same flash interface

Flash Sector Allocation:

- Sector 1 (FLASH_SECTOR_CAMERA): Camera images
- Sector 2 and 3: Camera stores in sector 1 and overflow to sectors 2 and 3 when needed.
- Sector 4:  unused
- Sector 5 (FLASH_SECTOR_ALTIMETER): Altimeter data (ready
 for future use)
- Sector 6 (FLASH_SECTOR_GPS): GPS data
- Sector 7:  Battery data and OBC Sensor Data (w/ offset and padding)