### PR TITLE
sensor bookkeeping in OBC interface

### DIFF
--- a/project/Core/Inc/obc_interface.h
+++ b/project/Core/Inc/obc_interface.h
@@ -50,9 +50,18 @@ typedef struct { 		// struct containing sensor data values
 } SensorsData;
 
 void init_sensors(); // initialises pins
-void save_sensor_data_to_flash(SensorsData *data); // handles saving to flash
-void load_sensor_data_from_flash(); // retrieves flash data and uses a pointer to write to the sensor_backup struct
-SensorsData read_sensors(); // polls sensors, calls save_sensor_data_to_flash, returns sensor data object
+void save_sensor_data_to_flash(SensorsData *data); // flash storage macro
+void load_sensor_data_from_flash(); // flash retrieval macro
+
+/*
+read_sensors:
+    macro polling sensor data to a SensorsData struct
+Parameters:
+    null
+Return:
+    returns a SensorsData struct  
+*/
+SensorsData read_sensors(); 
 
 float read_OBC_temperature(); // poll temperature sensor
 

--- a/project/Core/Src/obc_interface.c
+++ b/project/Core/Src/obc_interface.c
@@ -139,10 +139,10 @@ float read_OBC_temperature(){ // temperature hardware wrapper
     return raw;
 }
 
-//writes current sensor values to flash/global struct and returns struct with final values
+
 SensorsData read_sensors(){ 
-    SensorsData data; // initialise empty struct and/or write over flash
-    data.temperature_obc = read_OBC_temperature(); // store temperature and pressure to struct
+    SensorsData data; 
+    data.temperature_obc = read_OBC_temperature(); 
     data.temperature_ttc = read_TTC_temperature();
     data.temperature_bms = read_BMS_temperature();
     data.gyroscope_axis_1 = read_gyroscope_x1();
@@ -152,8 +152,7 @@ SensorsData read_sensors(){
     data.acceleration_axis_2 = read_acceleration_x2();
     data.acceleration_axis_3 = read_acceleration_x3();
     data.altitude = altimeter_read();
-    save_sensor_data_to_flash(&data);
-    return data; // return filled struct
+    return data; 
 }
 
 // Gyroscope (I2C)


### PR DESCRIPTION
removes flash write call from read_sensors function in obc_interface.c to align with data task implementation in obc.c, updates documentation in obc_interface.h