### PR TITLE
Added i2c sensor testing

### DIFF
--- a/.github/workflows/altimeter.yml
+++ b/.github/workflows/altimeter.yml
@@ -1,0 +1,60 @@
+name: Altimeter HIL Test
+
+on:
+  workflow_call:
+    inputs:
+      address:
+        description: I2C address of the altimeter to emulate (default 0x76)
+        required: false
+        default: 0x76
+        type: string
+      serial_port:
+        description: Serial device to read STM32 logs from
+        required: false
+        default: /dev/ttyACM0
+        type: string
+      duration_s:
+        description: Seconds to run the emulation and test
+        required: false
+        default: 30
+        type: number
+
+jobs:
+  run:
+    runs-on: self-hosted
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Start pigpio daemon (if available)
+        shell: bash
+        run: |
+          (which systemctl >/dev/null 2>&1 && sudo systemctl start pigpiod) || true
+          (which pigpiod >/dev/null 2>&1 && sudo pigpiod || true) || true
+
+      - name: Launch altimeter emulator
+        shell: bash
+        run: |
+          HIL_ADDR=${{ inputs.address }} HIL_SERIAL=${{ inputs.serial_port }} HIL_DURATION_S=${{ inputs.duration_s }} python3 hil_test.py altimeter &
+          echo $! > hil_pid.txt
+
+      - name: Flash STM32 firmware
+        shell: bash
+        run: |
+          arm-none-eabi-objcopy -O binary project/Debug/COMP_SLIP-OBC.elf COMP_SLIP-OBC.bin
+          st-flash write COMP_SLIP-OBC.bin 0x8000000
+          sleep 3
+          st-flash reset
+
+      - name: Wait for test window
+        shell: bash
+        run: |
+          sleep ${{ inputs.duration_s }}
+
+      - name: Stop emulator
+        if: always()
+        shell: bash
+        run: |
+          if [ -f hil_pid.txt ]; then kill $(cat hil_pid.txt) || true; fi
+
+

--- a/.github/workflows/gyroscope.yml
+++ b/.github/workflows/gyroscope.yml
@@ -1,0 +1,61 @@
+name: Gyroscope HIL Test
+
+on:
+  workflow_call:
+    inputs:
+      address:
+        description: I2C address of the gyroscope to emulate (default 0x68)
+        required: false
+        default: 0x68
+        type: string
+      serial_port:
+        description: Serial device to read STM32 logs from
+        required: false
+        default: /dev/ttyACM0
+        type: string
+      duration_s:
+        description: Seconds to run the emulation and test
+        required: false
+        default: 30
+        type: number
+
+jobs:
+  run:
+    runs-on: self-hosted
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Start pigpio daemon (if available)
+        shell: bash
+        run: |
+          (which systemctl >/dev/null 2>&1 && sudo systemctl start pigpiod) || true
+          (which pigpiod >/dev/null 2>&1 && sudo pigpiod || true) || true
+
+      - name: Launch gyroscope emulator (placeholder)
+        shell: bash
+        run: |
+          # Gyroscope emulator not yet implemented in hil_test.py; using temp mode as stub with address override
+          HIL_ADDR=${{ inputs.address }} HIL_SERIAL=${{ inputs.serial_port }} HIL_DURATION_S=${{ inputs.duration_s }} python3 hil_test.py temp &
+          echo $! > hil_pid.txt
+
+      - name: Flash STM32 firmware
+        shell: bash
+        run: |
+          arm-none-eabi-objcopy -O binary project/Debug/COMP_SLIP-OBC.elf COMP_SLIP-OBC.bin
+          st-flash write COMP_SLIP-OBC.bin 0x8000000
+          sleep 3
+          st-flash reset
+
+      - name: Wait for test window
+        shell: bash
+        run: |
+          sleep ${{ inputs.duration_s }}
+
+      - name: Stop emulator
+        if: always()
+        shell: bash
+        run: |
+          if [ -f hil_pid.txt ]; then kill $(cat hil_pid.txt) || true; fi
+
+

--- a/.github/workflows/sensor-accel.yml
+++ b/.github/workflows/sensor-accel.yml
@@ -1,0 +1,63 @@
+name: Sensor Accelerometer HIL Test
+
+on:
+  workflow_call:
+    inputs:
+      address:
+        description: I2C address of the accelerometer (default 0x1E)
+        required: false
+        default: '0x1E'
+        type: string
+      serial_port:
+        description: Serial device for STM32 logs
+        required: false
+        default: /dev/ttyACM0
+        type: string
+      duration_s:
+        description: Seconds to run
+        required: false
+        default: '30'
+        type: string
+
+concurrency:
+  group: hil-tests
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Start pigpio daemon
+        shell: bash
+        run: |
+          (which systemctl >/dev/null 2>&1 && sudo systemctl start pigpiod) || true
+          (which pigpiod >/dev/null 2>&1 && sudo pigpiod || true) || true
+
+      - name: Launch accelerometer emulator
+        shell: bash
+        run: |
+          HIL_ADDR=${{ inputs.address }} HIL_SERIAL=${{ inputs.serial_port }} HIL_DURATION_S=${{ inputs.duration_s }} python3 hil_test.py accel &
+          echo $! > hil_pid.txt
+
+      - name: Flash STM32 firmware
+        shell: bash
+        run: |
+          arm-none-eabi-objcopy -O binary project/Debug/COMP_SLIP-OBC.elf COMP_SLIP-OBC.bin
+          st-flash write COMP_SLIP-OBC.bin 0x8000000
+          sleep 3
+          st-flash reset
+
+      - name: Wait for test window
+        shell: bash
+        run: |
+          sleep ${{ inputs.duration_s }}
+
+      - name: Stop emulator
+        if: always()
+        shell: bash
+        run: |
+          if [ -f hil_pid.txt ]; then kill $(cat hil_pid.txt) || true; fi
+
+

--- a/.github/workflows/sensor-altimeter.yml
+++ b/.github/workflows/sensor-altimeter.yml
@@ -1,0 +1,63 @@
+name: Sensor Altimeter HIL Test
+
+on:
+  workflow_call:
+    inputs:
+      address:
+        description: I2C address of the altimeter (default 0x76)
+        required: false
+        default: '0x76'
+        type: string
+      serial_port:
+        description: Serial device for STM32 logs
+        required: false
+        default: /dev/ttyACM0
+        type: string
+      duration_s:
+        description: Seconds to run
+        required: false
+        default: '30'
+        type: string
+
+concurrency:
+  group: hil-tests
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Start pigpio daemon
+        shell: bash
+        run: |
+          (which systemctl >/dev/null 2>&1 && sudo systemctl start pigpiod) || true
+          (which pigpiod >/dev/null 2>&1 && sudo pigpiod || true) || true
+
+      - name: Launch altimeter emulator
+        shell: bash
+        run: |
+          HIL_ADDR=${{ inputs.address }} HIL_SERIAL=${{ inputs.serial_port }} HIL_DURATION_S=${{ inputs.duration_s }} python3 hil_test.py altimeter &
+          echo $! > hil_pid.txt
+
+      - name: Flash STM32 firmware
+        shell: bash
+        run: |
+          arm-none-eabi-objcopy -O binary project/Debug/COMP_SLIP-OBC.elf COMP_SLIP-OBC.bin
+          st-flash write COMP_SLIP-OBC.bin 0x8000000
+          sleep 3
+          st-flash reset
+
+      - name: Wait for test window
+        shell: bash
+        run: |
+          sleep ${{ inputs.duration_s }}
+
+      - name: Stop emulator
+        if: always()
+        shell: bash
+        run: |
+          if [ -f hil_pid.txt ]; then kill $(cat hil_pid.txt) || true; fi
+
+

--- a/.github/workflows/sensor-gyro.yml
+++ b/.github/workflows/sensor-gyro.yml
@@ -1,0 +1,63 @@
+name: Sensor Gyroscope HIL Test
+
+on:
+  workflow_call:
+    inputs:
+      address:
+        description: I2C address of the gyroscope (default 0x68)
+        required: false
+        default: '0x68'
+        type: string
+      serial_port:
+        description: Serial device for STM32 logs
+        required: false
+        default: /dev/ttyACM0
+        type: string
+      duration_s:
+        description: Seconds to run
+        required: false
+        default: '30'
+        type: string
+
+concurrency:
+  group: hil-tests
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Start pigpio daemon
+        shell: bash
+        run: |
+          (which systemctl >/dev/null 2>&1 && sudo systemctl start pigpiod) || true
+          (which pigpiod >/dev/null 2>&1 && sudo pigpiod || true) || true
+
+      - name: Launch gyro emulator
+        shell: bash
+        run: |
+          HIL_ADDR=${{ inputs.address }} HIL_SERIAL=${{ inputs.serial_port }} HIL_DURATION_S=${{ inputs.duration_s }} python3 hil_test.py gyro &
+          echo $! > hil_pid.txt
+
+      - name: Flash STM32 firmware
+        shell: bash
+        run: |
+          arm-none-eabi-objcopy -O binary project/Debug/COMP_SLIP-OBC.elf COMP_SLIP-OBC.bin
+          st-flash write COMP_SLIP-OBC.bin 0x8000000
+          sleep 3
+          st-flash reset
+
+      - name: Wait for test window
+        shell: bash
+        run: |
+          sleep ${{ inputs.duration_s }}
+
+      - name: Stop emulator
+        if: always()
+        shell: bash
+        run: |
+          if [ -f hil_pid.txt ]; then kill $(cat hil_pid.txt) || true; fi
+
+

--- a/.github/workflows/sensor-temp.yml
+++ b/.github/workflows/sensor-temp.yml
@@ -1,0 +1,62 @@
+name: Sensor Temp HIL Test
+
+on:
+  workflow_call:
+    inputs:
+      address:
+        description: I2C address of the temp sensor (0x48, 0x49, 0x4A, 0x4B)
+        required: true
+        type: string
+      serial_port:
+        description: Serial device for STM32 logs
+        required: false
+        default: /dev/ttyACM0
+        type: string
+      duration_s:
+        description: Seconds to run
+        required: false
+        default: '30'
+        type: string
+
+concurrency:
+  group: hil-tests
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Start pigpio daemon
+        shell: bash
+        run: |
+          (which systemctl >/dev/null 2>&1 && sudo systemctl start pigpiod) || true
+          (which pigpiod >/dev/null 2>&1 && sudo pigpiod || true) || true
+
+      - name: Launch temp sensor emulator
+        shell: bash
+        run: |
+          HIL_ADDR=${{ inputs.address }} HIL_SERIAL=${{ inputs.serial_port }} HIL_DURATION_S=${{ inputs.duration_s }} python3 hil_test.py temp &
+          echo $! > hil_pid.txt
+
+      - name: Flash STM32 firmware
+        shell: bash
+        run: |
+          arm-none-eabi-objcopy -O binary project/Debug/COMP_SLIP-OBC.elf COMP_SLIP-OBC.bin
+          st-flash write COMP_SLIP-OBC.bin 0x8000000
+          sleep 3
+          st-flash reset
+
+      - name: Wait for test window
+        shell: bash
+        run: |
+          sleep ${{ inputs.duration_s }}
+
+      - name: Stop emulator
+        if: always()
+        shell: bash
+        run: |
+          if [ -f hil_pid.txt ]; then kill $(cat hil_pid.txt) || true; fi
+
+

--- a/.github/workflows/sensors-suite.yml
+++ b/.github/workflows/sensors-suite.yml
@@ -1,0 +1,58 @@
+name: Sensors Suite
+
+on:
+  workflow_dispatch:
+    inputs:
+      which:
+        description: Which HIL test to run (all, temp, altimeter, gyro, accel)
+        required: false
+        default: all
+        type: choice
+        options:
+          - all
+          - temp
+          - altimeter
+          - gyro
+          - accel
+
+concurrency:
+  group: hil-tests
+  cancel-in-progress: false
+
+jobs:
+  temp:
+    if: ${{ github.event.inputs.which == 'temp' || github.event.inputs.which == 'all' || github.event.inputs.which == '' }}
+    uses: ./.github/workflows/sensor-temp.yml
+    with:
+      address: '0x4A'
+      serial_port: '/dev/ttyACM0'
+      duration_s: '30'
+
+  altimeter:
+    if: ${{ github.event.inputs.which == 'altimeter' || github.event.inputs.which == 'all' || github.event.inputs.which == '' }}
+    needs: [temp]
+    uses: ./.github/workflows/sensor-altimeter.yml
+    with:
+      address: '0x76'
+      serial_port: '/dev/ttyACM0'
+      duration_s: '30'
+
+  gyro:
+    if: ${{ github.event.inputs.which == 'gyro' || github.event.inputs.which == 'all' || github.event.inputs.which == '' }}
+    needs: [altimeter]
+    uses: ./.github/workflows/sensor-gyro.yml
+    with:
+      address: '0x68'
+      serial_port: '/dev/ttyACM0'
+      duration_s: '30'
+
+  accel:
+    if: ${{ github.event.inputs.which == 'accel' || github.event.inputs.which == 'all' || github.event.inputs.which == '' }}
+    needs: [gyro]
+    uses: ./.github/workflows/sensor-accel.yml
+    with:
+      address: '0x1E'
+      serial_port: '/dev/ttyACM0'
+      duration_s: '30'
+
+

--- a/.github/workflows/temp_sensor.yml
+++ b/.github/workflows/temp_sensor.yml
@@ -1,0 +1,59 @@
+name: Temp Sensor HIL Test
+
+on:
+  workflow_call:
+    inputs:
+      address:
+        description: I2C address of the temp sensor to emulate (e.g. 0x48, 0x49, 0x4A, 0x4B)
+        required: true
+        type: string
+      serial_port:
+        description: Serial device to read STM32 logs from
+        required: false
+        default: /dev/ttyACM0
+        type: string
+      duration_s:
+        description: Seconds to run the emulation and test
+        required: false
+        default: 30
+        type: number
+
+jobs:
+  run:
+    runs-on: self-hosted
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Start pigpio daemon (if available)
+        shell: bash
+        run: |
+          (which systemctl >/dev/null 2>&1 && sudo systemctl start pigpiod) || true
+          (which pigpiod >/dev/null 2>&1 && sudo pigpiod || true) || true
+
+      - name: Launch temp sensor emulator
+        shell: bash
+        run: |
+          HIL_ADDR=${{ inputs.address }} HIL_SERIAL=${{ inputs.serial_port }} HIL_DURATION_S=${{ inputs.duration_s }} python3 hil_test.py temp &
+          echo $! > hil_pid.txt
+
+      - name: Flash STM32 firmware
+        shell: bash
+        run: |
+          arm-none-eabi-objcopy -O binary project/Debug/COMP_SLIP-OBC.elf COMP_SLIP-OBC.bin
+          st-flash write COMP_SLIP-OBC.bin 0x8000000
+          sleep 3
+          st-flash reset
+
+      - name: Wait for test window
+        shell: bash
+        run: |
+          sleep ${{ inputs.duration_s }}
+
+      - name: Stop emulator
+        if: always()
+        shell: bash
+        run: |
+          if [ -f hil_pid.txt ]; then kill $(cat hil_pid.txt) || true; fi
+
+

--- a/hil_test.py
+++ b/hil_test.py
@@ -1,79 +1,303 @@
-import RPi.GPIO as GPIO
+import os
+import sys
 import time
 import serial
-import os
 
-# Pin definitions
-CAM1_PD_PIN = 17
-CAM1_RT_PIN = 18
-CAM_SEL_PIN = 27
-CAM2_PD_PIN = 22
-CAM2_RT_PIN = 23
-TRANSCIEVER_EXTI_PIN = 24
+try:
+    import pigpio
+except ImportError:
+    pigpio = None
 
-def setup_gpio():
-    """Sets up the GPIO pins on the Raspberry Pi."""
-    GPIO.setmode(GPIO.BCM)
-    GPIO.setup(CAM1_PD_PIN, GPIO.OUT)
-    GPIO.setup(CAM1_RT_PIN, GPIO.OUT)
-    GPIO.setup(CAM_SEL_PIN, GPIO.OUT)
-    GPIO.setup(CAM2_PD_PIN, GPIO.OUT)
-    GPIO.setup(CAM2_RT_PIN, GPIO.OUT)
-    GPIO.setup(TRANSCIEVER_EXTI_PIN, GPIO.IN)
-    print("GPIO setup complete.")
 
-def emulate_sensors():
-    """Emulates sensor values by controlling GPIO pins."""
-    print("Emulating sensor values...")
-    # Example: Toggle camera power and select
-    GPIO.output(CAM1_PD_PIN, GPIO.HIGH)
-    time.sleep(1)
-    GPIO.output(CAM_SEL_PIN, GPIO.HIGH)
-    time.sleep(1)
-    GPIO.output(CAM1_PD_PIN, GPIO.LOW)
-    time.sleep(1)
-    GPIO.output(CAM_SEL_PIN, GPIO.LOW)
-    print("Sensor emulation finished.")
+class AltimeterMS5611Emulator:
+    """
+    Minimal MS5611-compatible emulator for address 0x76.
+    Matches STM32 transactions in `project/Core/Src/obc_interface.c`:
+      - Reset:           0x1E
+      - Convert D1:      0x48 (pressure)
+      - Convert D2:      0x58 (temperature)
+      - ADC read:        0x00 (then master reads 3 bytes)
+      - PROM reads:      0xA2, 0xA4, 0xA6, 0xA8, 0xAA, 0xAC (each 2 bytes)
+    """
 
-def wait_for_serial_and_read():
-    """Waits for the serial port to be available, then reads data."""
-    serial_port = '/dev/ttyACM0'
+    def __init__(self) -> None:
+        self._last_conv = None  # 'D1' or 'D2'
+        # Fixed PROM coefficients (C1..C6). Values are arbitrary but consistent.
+        self._prom = {
+            0xA2: (0x6A, 0x86),  # C1
+            0xA4: (0x67, 0x12),  # C2
+            0xA6: (0x7B, 0x45),  # C3
+            0xA8: (0x5C, 0xE3),  # C4
+            0xAA: (0x83, 0x19),  # C5
+            0xAC: (0x73, 0xB2),  # C6
+        }
+        # Synthetic base values for pressure/temperature ADC (24-bit)
+        self._d1_base = 0x640000  # pressure
+        self._d2_base = 0x500000  # temperature
+        self._tick = 0
+
+    def handle_write(self, payload: bytes) -> bytes | None:
+        # Process command bytes from master (write transfers).
+        tx = None
+        for byte in payload:
+            if byte == 0x1E:  # Reset
+                self._last_conv = None
+                self._tick = 0
+            elif byte == 0x48:  # D1 conversion (pressure)
+                self._last_conv = 'D1'
+                self._tick += 1
+            elif byte == 0x58:  # D2 conversion (temperature)
+                self._last_conv = 'D2'
+                self._tick += 1
+            elif byte == 0x00:  # ADC read request will follow as a read
+                # Prepare 3 output bytes immediately
+                if self._last_conv == 'D1':
+                    value = (self._d1_base + (self._tick & 0xFF)) & 0xFFFFFF
+                elif self._last_conv == 'D2':
+                    value = (self._d2_base + (self._tick & 0xFF)) & 0xFFFFFF
+                else:
+                    value = 0x000000
+                tx = bytes([(value >> 16) & 0xFF, (value >> 8) & 0xFF, value & 0xFF])
+            elif byte in self._prom:  # PROM read command
+                # Master will do a 2-byte read next
+                hi, lo = self._prom[byte]
+                tx = bytes([hi, lo])
+            else:
+                # Ignore unknown commands
+                pass
+        return tx
+
+
+class Temp12BitEmulator:
+    """
+    Minimal 12-bit temperature sensor emulator at given address, responding to
+    an 8-bit register 0x00 read of 2 bytes. The STM32 packs as:
+      temp_raw = (raw[0] << 4) | (raw[1] >> 4)
+    """
+
+    def __init__(self, raw_value_12bit: int = 0x640) -> None:
+        self._raw12 = max(0, min(0xFFF, raw_value_12bit))
+        self._reg_ptr = 0x00
+
+    def handle_write(self, payload: bytes) -> bytes | None:
+        tx = None
+        for i, byte in enumerate(payload):
+            if i == 0:
+                # Register pointer
+                self._reg_ptr = byte
+                if self._reg_ptr == 0x00:
+                    hi = (self._raw12 >> 4) & 0xFF
+                    lo = (self._raw12 & 0x0F) << 4
+                    tx = bytes([hi, lo])
+            else:
+                # Ignore writes to config registers for now
+                pass
+        return tx
+
+
+class I2CSlave:
+    """
+    Thin wrapper over pigpio BSC to expose an I2C slave at a given address and
+    serve data prepared by an emulator.
+    Uses GPIO 18 (SDA) and GPIO 19 (SCL) as per BSC peripheral.
+    """
+
+    def __init__(self, address: int, emulator: object) -> None:
+        if pigpio is None:
+            raise RuntimeError("pigpio is required for I2C slave emulation. Install pigpio and run pigpiod.")
+        self._address = address & 0x7F
+        self._emulator = emulator
+        self._pi = pigpio.pi()
+        if not self._pi.connected:
+            raise RuntimeError("Failed to connect to pigpio daemon. Ensure pigpiod is running.")
+        # Enable BSC peripheral in I2C slave mode
+        self._pi.bsc_i2c(self._address)
+
+    def close(self) -> None:
+        try:
+            self._pi.bsc_i2c(0)  # disable
+        finally:
+            self._pi.stop()
+
+    def serve_forever(self, run_seconds: float | None = None) -> None:
+        start = time.time()
+        pending_tx = b""
+        try:
+            while True:
+                now = time.time()
+                if run_seconds is not None and (now - start) > run_seconds:
+                    break
+                # Provide last prepared TX (if any). This call also collects RX.
+                status, rx_bytes = self._xfer(pending_tx)
+                pending_tx = b""  # consumed
+
+                if status < 0:
+                    # Brief sleep to avoid tight loop on errors
+                    time.sleep(0.001)
+                    continue
+
+                if rx_bytes:
+                    prepared = self._emulator.handle_write(rx_bytes)
+                    if prepared:
+                        # Queue bytes to be clocked out on the master's next read
+                        pending_tx = prepared
+                else:
+                    # Idle
+                    time.sleep(0.0005)
+        finally:
+            pass
+
+    def _xfer(self, tx: bytes) -> tuple[int, bytes]:
+        # pigpio bsc_xfer takes a dict with 'txBuf'
+        x = self._pi.bsc_xfer(tx)
+        status = x.get('status', 0)
+        rx_len = x.get('rxLen', 0)
+        rx = x.get('rxBuf', b"") if rx_len else b""
+        return status, rx
+
+
+class Vector3Emulator:
+    """
+    Minimal vector-3 emulator (e.g., accelerometer/gyroscope) that returns 6 bytes
+    (three 16-bit big-endian signed values) when register pointer is set to 0x00.
+    """
+
+    def __init__(self, base_xyz: tuple[int, int, int] = (100, 200, -150)) -> None:
+        self._reg_ptr = 0x00
+        self._x, self._y, self._z = base_xyz
+        self._tick = 0
+
+    def handle_write(self, payload: bytes) -> bytes | None:
+        tx = None
+        for i, byte in enumerate(payload):
+            if i == 0:
+                self._reg_ptr = byte
+                if self._reg_ptr == 0x00:
+                    # Slowly vary values each call
+                    self._tick = (self._tick + 1) & 0xFFFF
+                    x = (self._x + (self._tick % 5))
+                    y = (self._y - (self._tick % 5))
+                    z = (self._z + ((self._tick // 2) % 5))
+                    def pack16(n: int) -> tuple[int, int]:
+                        n &= 0xFFFF
+                        return (n >> 8) & 0xFF, n & 0xFF
+                    xh, xl = pack16(x & 0xFFFF)
+                    yh, yl = pack16(y & 0xFFFF)
+                    zh, zl = pack16(z & 0xFFFF)
+                    tx = bytes([xh, xl, yh, yl, zh, zl])
+        return tx
+
+
+def wait_for_serial_and_read(serial_port: str = '/dev/ttyACM0') -> None:
     print(f"Waiting for serial port {serial_port} to become available...")
-    
-    # Wait for the STM32 to be flashed and the serial port to appear
     while not os.path.exists(serial_port):
         time.sleep(1)
-    
     print(f"Serial port {serial_port} is available.")
-    time.sleep(2)  # Give the serial port some time to initialize
-
-    # Now that the board is ready, emulate the sensors
-    emulate_sensors()
+    time.sleep(1.5)
 
     try:
-        ser = serial.Serial(serial_port, 115200, timeout=10)
+        ser = serial.Serial(serial_port, 115200, timeout=5)
         print(f"Reading from serial port {serial_port}...")
         while True:
-            line = ser.readline().decode('utf-8').strip()
+            line = ser.readline().decode('utf-8', errors='ignore').strip()
             if line:
-                print(f"Received: {line}")
-            else:
-                print("No data received for 10 seconds. Exiting.")
-                break
+                print(f"[STM32] {line}")
     except serial.SerialException as e:
-        print(f"Error reading from serial port: {e}")
+        print(f"Serial error: {e}")
     finally:
-        if 'ser' in locals() and ser.is_open:
-            ser.close()
+        try:
+            if 'ser' in locals() and ser.is_open:
+                ser.close()
+        except Exception:
+            pass
 
-def main():
-    """Main function to run the hardware-in-the-loop test."""
+
+def main() -> None:
+    # Mode selection via env or args
+    mode = os.environ.get('HIL_MODE') or (sys.argv[1] if len(sys.argv) > 1 else 'altimeter')
+    if mode not in ('altimeter', 'temp', 'gyro', 'accel'):
+        print("Usage: python3 hil_test.py [altimeter|temp|gyro|accel]")
+        sys.exit(1)
+
+    # Address selection
+    addr_env = os.environ.get('HIL_ADDR')
+    default_addr = 0x76 if mode == 'altimeter' else (0x4A if mode == 'temp' else (0x68 if mode == 'gyro' else 0x1E))
+    address = int(addr_env, 0) if addr_env else default_addr
+
+    # Optional: how long to run the I2C slave (seconds). None = forever
+    run_seconds_env = os.environ.get('HIL_DURATION_S')
+    run_seconds = float(run_seconds_env) if run_seconds_env else None
+
+    # Start emulator
+    if mode == 'altimeter':
+        emulator = AltimeterMS5611Emulator()
+    elif mode == 'temp':
+        emulator = Temp12BitEmulator()
+    else:
+        # gyro/accel vector emulators
+        emulator = Vector3Emulator()
+
+    slave = None
     try:
-        setup_gpio()
-        wait_for_serial_and_read()
+        print(f"Starting I2C slave: mode={mode}, address=0x{address:02X}")
+        slave = I2CSlave(address=address, emulator=emulator)
+
+        # Run sensor emulator and serial reader concurrently (very simple coop)
+        # Start serial reader in a background-like fashion using a lightweight loop
+        # that interleaves with the I2C serving loop by non-blocking checks.
+        # For simplicity, spawn a minimal thread-less interleave.
+
+        last_serial_check = 0.0
+        serial_started = False
+        ser = None
+
+        start = time.time()
+        pending_tx = b""
+        while True:
+            # Serve I2C for a short slice
+            status, rx_bytes = slave._xfer(pending_tx)
+            pending_tx = b""
+            if rx_bytes:
+                prepared = emulator.handle_write(rx_bytes)
+                if prepared:
+                    pending_tx = prepared
+
+            # Periodically try to start serial and read a line
+            now = time.time()
+            if not serial_started and (now - last_serial_check) > 0.5:
+                last_serial_check = now
+                port = os.environ.get('HIL_SERIAL', '/dev/ttyACM0')
+                if os.path.exists(port):
+                    try:
+                        ser = serial.Serial(port, 115200, timeout=0)
+                        serial_started = True
+                        print(f"Serial attached: {port}")
+                    except Exception:
+                        pass
+            if serial_started and ser is not None:
+                try:
+                    line = ser.readline().decode('utf-8', errors='ignore').strip()
+                    if line:
+                        print(f"[STM32] {line}")
+                except Exception:
+                    pass
+
+            if run_seconds is not None and (now - start) > run_seconds:
+                break
+
+            # Tiny sleep to reduce CPU usage
+            time.sleep(0.0005)
+
+        if ser is not None:
+            try:
+                ser.close()
+            except Exception:
+                pass
+
     finally:
-        GPIO.cleanup()
-        print("GPIO cleaned up.")
+        if slave is not None:
+            slave.close()
+
 
 if __name__ == "__main__":
-    main() 
+    main()


### PR DESCRIPTION
This PR adds automated github actions to test all sensors based on the pin configurations from elec.
**Note**: This runs tests sequentially, as we can’t run multiple sensor tests at the same time due to Raspberry Pi hardware limitations: the Pi’s I²C slave mode can only handle one address and one bus at a time.