### PR TITLE
Move retransmission definitions to main.h to fix compile errors

### DIFF
--- a/project/Core/Inc/FreeRTOSConfig.h
+++ b/project/Core/Inc/FreeRTOSConfig.h
@@ -78,10 +78,7 @@
 #define configUSE_RECURSIVE_MUTEXES              1
 #define configUSE_COUNTING_SEMAPHORES            1
 #define configUSE_PORT_OPTIMISED_TASK_SELECTION  0
-#define configUSE_TIMERS						 1
-#define configTIMER_TASK_PRIORITY				 2 /* Change to actual priority */
-#define configTIMER_QUEUE_LENGTH				 1
-#define configTIMER_TASK_STACK_DEPTH			 1
+
 /* USER CODE BEGIN MESSAGE_BUFFER_LENGTH_TYPE */
 /* Defaults to size_t for backward compatibility, but can be changed
    if lengths will always be less than the number of bytes in a size_t. */

--- a/project/Core/Inc/main.h
+++ b/project/Core/Inc/main.h
@@ -41,6 +41,7 @@ extern "C"
 #include "string.h"
 #include "stdio.h"
 #include "semphr.h"
+#include "timers.h"
 
   /* USER CODE END Includes */
 
@@ -51,7 +52,8 @@ extern "C"
 
   /* Exported constants --------------------------------------------------------*/
   /* USER CODE BEGIN EC */
-
+// Retransmission software timer
+TimerHandle_t retransmission_timer;
   /* USER CODE END EC */
 
   /* Exported macro ------------------------------------------------------------*/
@@ -69,6 +71,9 @@ extern "C"
   void data_task(void *vpParameters);
   void low_power_task(void *vpParameters);
   void receive(void *vpParameters);
+
+  /* Definitions for retransmission software timer */
+  void vRetransmissionTimerCallback( TimerHandle_t xTimer );
 
   /* USER CODE END EFP */
 

--- a/project/Core/Inc/ttc.h
+++ b/project/Core/Inc/ttc.h
@@ -1,19 +1,26 @@
 #ifndef TTC_H
 #define TTC_H
 #include "ttc_interface.h"
+#include "timers.h"
 
 #define COMM_NOMINAL 1
 #define COMM_LOST 0
-
-/* Timer handle, created in main */
-extern TimerHandle_t retransmission_timer; // Timer handle, created in main
 
 /**
  * ttc_notifications:
  * Task that receives notifications from OBC tasks and handles them; 
  * transmits error, telemetry, and image data packets.
+ *
+ * Declared in main.h
  */
-void ttc_notifications(void *vpParameters);
+
+/**
+ * receive:
+ * Task which parses data received from the TTC and starts
+ * appropriate actions.
+ *
+ * Declared in main.h
+ */
 
 /**
  * handle_transmit:
@@ -33,15 +40,10 @@ void handle_transmit(int acknowlegement);
  * 
  * Parameters:
  * xTimer: Timer handle
+ *
+ * Declared in main.h
  */
-void vRetransmissionTimerCallback( TimerHandle_t xTimer );
 
-/**
- * receive:
- * Task which parses data received from the TTC and starts
- * appropriate actions.
- */
-void receive(void *vpParameters);
 
 void Task_receiveLL(void *vpParamemeters);
 

--- a/project/Core/Inc/ttc_interface.h
+++ b/project/Core/Inc/ttc_interface.h
@@ -8,6 +8,7 @@
 #include <semphr.h>
 #include "stm32h7xx_hal.h"
 #include "stm32h7xx_hal_spi.h"
+#include "main.h"
 
 typedef uint8_t FIFOsize[128]; // new typedef used for defining FIFO size as mentioned in the CC1201 datasheet
 
@@ -31,7 +32,7 @@ typedef enum
 	ACK_REC_ERROR = 0b00001111,
 } PayloadType;
 
-const MAX_TRANS_ATTEMPTS = 5;
+#define MAX_TRANS_ATTEMPTS 5
 
 extern osMessageQueueId_t receivequeueHandle; // the message queue used for receiving info from the trasnciever
 extern osSemaphoreId_t myBinarySem01Handle;   // used to protect the dirty bit. it is a sempahore

--- a/project/Core/Src/main.c
+++ b/project/Core/Src/main.c
@@ -83,9 +83,6 @@ const osMessageQueueAttr_t receivequeue_attributes = {
 osSemaphoreId_t myBinarySem01Handle;
 const osSemaphoreAttr_t myBinarySem01_attributes = {
     .name = "myBinarySem01"};
-/* Definitions for retransmission software timer */
-TimerHandle_t retransmission_timer;
-int retransmission_timer_id = 0;
 /* USER CODE BEGIN PV */
 
 SemaphoreHandle_t image_mutex;
@@ -179,7 +176,7 @@ int main(void)
 
   /* USER CODE BEGIN RTOS_TIMERS */
   /* start timers, add new ones, ... */
-  retransmission_timer = xTimerCreate(“Retransmission timer”, pdMS_TO_TICKS(ACK_RECV_TIMEOUT), pdTRUE, retransmission_timer_id, vRetransmissionTimerCallback);
+  retransmission_timer = xTimerCreate(“Retransmission timer”, pdMS_TO_TICKS(ACK_RECV_TIMEOUT), pdTRUE, (void *) 0, vRetransmissionTimerCallback);
   /* USER CODE END RTOS_TIMERS */
 
   /* Create the queue(s) */

--- a/project/Core/Src/main.c
+++ b/project/Core/Src/main.c
@@ -176,7 +176,7 @@ int main(void)
 
   /* USER CODE BEGIN RTOS_TIMERS */
   /* start timers, add new ones, ... */
-  retransmission_timer = xTimerCreate(“Retransmission timer”, pdMS_TO_TICKS(ACK_RECV_TIMEOUT), pdTRUE, (void *) 0, vRetransmissionTimerCallback);
+  retransmission_timer = xTimerCreate("Retransmission timer", pdMS_TO_TICKS(ACK_RECV_TIMEOUT), pdTRUE, (void *) 0, vRetransmissionTimerCallback);
   /* USER CODE END RTOS_TIMERS */
 
   /* Create the queue(s) */


### PR DESCRIPTION
Move definitions for the retransmission timer and callback function to `main.h` and fix some ttc declarations to fix compile errors.